### PR TITLE
Command line graph cut

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,9 @@ add_executable(BSH_GUI apps/bsh_ui.cpp apps/UI.h)
 target_link_libraries(BSH_GUI bsh CLI11::CLI11 nlohmann::json igl::core igl_opengl_glfw_imgui
         arrangement)
 
+add_executable(graph_cut apps/graph_cut.cpp)
+target_link_libraries(graph_cut PRIVATE bsh)
+
 
 # unit tests
 #add_executable(mesh_arrangement apps/mesh_arrangement.cpp)

--- a/apps/graph_cut.cpp
+++ b/apps/graph_cut.cpp
@@ -1,0 +1,173 @@
+#include <BSH.h>
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <string>
+
+constexpr size_t INVALID = std::numeric_limits<size_t>::max();
+
+struct ArrangementGraph
+{
+    struct Patch
+    {
+        size_t adj_cell_0 = INVALID;
+        size_t adj_cell_1 = INVALID;
+
+        double weight = -1;
+        size_t implicit_id = INVALID;
+        size_t num_samples = 0;
+        std::vector<size_t> adj_patches;
+    };
+
+    size_t num_cells;
+    std::vector<Patch> patches;
+};
+
+void print_graph(const ArrangementGraph& g)
+{
+    std::cout << "num_cells: " << g.num_cells << std::endl;
+    const size_t num_patches = g.patches.size();
+    for (size_t i = 0; i < num_patches; i++) {
+        const auto& p = g.patches[i];
+        std::cout << "(" << p.adj_cell_0 << ", " << p.adj_cell_1 << "): " << p.weight
+                  << " func_id: " << p.implicit_id << " #samples: " << p.num_samples
+                  << " adj_patches: ";
+        for (auto adj_p : p.adj_patches) {
+            std::cout << " " << adj_p;
+        }
+        std::cout << std::endl;
+    }
+}
+
+ArrangementGraph load_graph(const std::string& filename)
+{
+    std::ifstream fin(filename.c_str());
+    nlohmann::json info;
+    fin >> info;
+
+    ArrangementGraph g;
+    g.num_cells = info["num_cells"];
+
+    const auto& info_patches = info["patches"];
+    size_t num_patches = info_patches.size();
+    g.patches.reserve(num_patches);
+    for (size_t i = 0; i < num_patches; i++) {
+        const auto& patch = info_patches[i];
+        ArrangementGraph::Patch p;
+        p.adj_cell_0 = patch["adj_cell_0"].get<size_t>();
+        p.adj_cell_1 = patch["adj_cell_1"].get<size_t>();
+        p.weight = patch["weight"].get<size_t>();
+        p.implicit_id = patch["implicit_id"].get<size_t>();
+        p.num_samples = patch["num_samples"].get<size_t>();
+
+        size_t num_adj_patches = patch["adj_patches"].size();
+        p.adj_patches.reserve(num_adj_patches);
+        for (auto adj_p : patch["adj_patches"]) {
+            p.adj_patches.push_back(adj_p);
+        }
+
+        g.patches.push_back(std::move(p));
+    }
+
+    return g;
+}
+
+std::vector<bool> graph_cut(const ArrangementGraph& g)
+{
+    const size_t num_cells = g.num_cells;
+    const size_t num_patches = g.patches.size();
+
+    std::vector<double> P_dist;
+    std::vector<std::vector<int>> P_samples;
+    std::vector<std::vector<int>> P_block;
+    std::vector<std::vector<int>> P_sign;
+    std::vector<std::vector<int>> B_patch;
+    std::vector<std::vector<int>> P_Adj_same;
+    std::vector<std::vector<int>> P_Adj_diff;
+    int topK = 1;
+    bool consider_adj_diff = true;
+    int max_search_count = std::numeric_limits<int>::max();
+
+    P_dist.reserve(num_patches);
+    P_samples.reserve(num_patches);
+    P_block.reserve(num_patches);
+    P_sign.reserve(num_patches);
+    B_patch.resize(num_cells);
+
+    size_t sample_count = 0;
+    for (size_t i = 0; i < num_patches; i++) {
+        const auto& p = g.patches[i];
+        P_dist.push_back(p.weight);
+        P_block.push_back({static_cast<int>(p.adj_cell_0), static_cast<int>(p.adj_cell_1)});
+        P_sign.push_back({1, -1});
+
+        P_samples.emplace_back();
+        auto& samples = P_samples.back();
+        for (size_t j=0; j<p.num_samples; j++) {
+            samples.push_back(sample_count);
+            sample_count++;
+        }
+
+        B_patch[p.adj_cell_0].push_back(i);
+        B_patch[p.adj_cell_1].push_back(i);
+    }
+
+    P_Adj_same.resize(num_patches);
+    P_Adj_diff.resize(num_patches);
+    for (size_t i = 0; i < num_patches; i++) {
+        const auto& p = g.patches[i];
+        const auto& adj_patches = p.adj_patches;
+        for (auto j : adj_patches) {
+            if (g.patches[i].implicit_id == g.patches[j].implicit_id) {
+                P_Adj_same[i].push_back(j);
+            } else {
+                P_Adj_diff[i].push_back(j);
+            }
+        }
+    }
+
+    std::vector<bool> B_label;
+    std::vector<bool> P_label;
+    std::vector<int>  P_prohibited;
+    BSH::connected_graph_cut(P_dist,
+        P_samples,
+        P_block,
+        P_sign,
+        B_patch,
+        P_Adj_same,
+        P_Adj_diff,
+        topK,
+        consider_adj_diff,
+        max_search_count,
+        B_label,
+        P_label,
+        P_prohibited);
+
+    return B_label;
+}
+
+void save_labels(const std::string& filename, const std::vector<bool>& labels) {
+    std::ofstream fout(filename.c_str());
+    nlohmann::json info;
+    info["labels"] = labels;
+    fout << info;
+}
+
+int main(int argc, char** argv)
+{
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " input_graph.json output_label.json" << std::endl;
+        return 1;
+    }
+
+    auto g = load_graph(argv[1]);
+    print_graph(g);
+
+    auto labels = graph_cut(g);
+    save_labels(argv[2], labels);
+
+    return 0;
+}

--- a/cmake/armadillo.cmake
+++ b/cmake/armadillo.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     armadillo
     GIT_REPOSITORY https://gitlab.com/conradsnicta/armadillo-code.git
-    GIT_TAG aa8ee5e1c0f6288419445aed21e9aff8fba4ea1c
+    GIT_TAG 7b9215a35870e2ff3a7522eacf815f8f4a8489f7
     GIT_SHALLOW TRUE
 )
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Do not use shared lib.")

--- a/src/BSH.cpp
+++ b/src/BSH.cpp
@@ -353,6 +353,13 @@ void BSH::connected_graph_cut(
         std::cout << "------ state " << search_count << " ------" << std::endl;
         std::cout << "cost: " << s.cost << ", ";
         std::cout << components.size() << " unsampled patch components." << std::endl;
+        for (const auto& comp : components) {
+            std::cout << "  ";
+            for (int i : comp) {
+                std::cout << i << " ";
+            }
+            std::cout << std::endl;
+        }
         std::cout << "prohibited patches:" << std::endl;
         for (auto i : s.prohibited_patches) {
             std::cout << i << ",";

--- a/src/BSH.h
+++ b/src/BSH.h
@@ -114,6 +114,7 @@ protected:
 
     void connected_graph_cut();
 
+public:
     /**
      * Run iterative graph cut algorithm.
      * @param[in]  P_dist  Per-ppatch weights.  It is an array of size
@@ -165,6 +166,7 @@ protected:
             std::vector<int>  &P_prohibited
             );
 
+protected:
     // export intermediate state for state-space search
     static bool export_state(const std::string &filename,
                              const std::vector<bool> &P_label,

--- a/src/BSH.h
+++ b/src/BSH.h
@@ -114,6 +114,41 @@ protected:
 
     void connected_graph_cut();
 
+    /**
+     * Run iterative graph cut algorithm.
+     * @param[in]  P_dist  Per-ppatch weights.  It is an array of size
+     *                     #Patches. Each entry represents the distance-weighted
+     *                     patch area.
+     * @param[in]  P_samples  Indices of sample points on each patch.
+     * @param[in]  P_block Patch-block adjacency list.  It is an array of size
+     *                     #Patches. Each subarray is of size 2, representing
+     *                     the block id on the positive and negative side of the
+     *                     patch (the orientation is specified in `P_sign`).
+     * @param[in]  P_sign  Patch orientations.  It is an array of size #Patches.
+     *                     Each subarray is of size 2.  `P_sign[i][0] > 0` means
+     *                     that the block indexed by `P_block[i][0]` is on the
+     *                     positive side of the patch.
+     * @param[in]  B_patch Block-patch adjacency list.  It is an array of size
+     *                     #Blocks.  Each subarray is a list of patch ids
+     *                     representing the patching bounding this block.
+     * @param[in]  P_Adj_same `P_Adj_same[i]` is the list of indices of patches
+     *                        that are adjacent to patch i and on the same
+     *                        implicit surface.
+     * @param[in]  P_Adj_diff `P_Adj_diff[i]` is the list of indices of patches
+     *                        that are adjacent to patch i but not on the same
+     *                        implicit surface.
+     *
+     * @param[in]  topK    K value (see paper, suggested value: 1).
+     * @param[in]  consider_adj_diff  Whether to consider adjacent patch
+     *                                to islands in state space search.
+     *                                (suggested value: true)
+     * @param[in]  max_search_count  Max search count.  (suggested value: inf)
+     *
+     * @param[out]  B_label In/out label per block.
+     * @param[out]  P_label whether each patch is active.
+     * @param[out]  P_prohibited Patches prohibited to be part of the final
+     *                           surface in the state-space search.
+     */
     static void connected_graph_cut(
             //input
             const std::vector<double> &P_dist,


### PR DESCRIPTION
### Summary
* Add a command line program that just runs the iterative graph cut algorithm.

### Usage
```sh
./graph_cut [input_arrangement_graph.json] [output_label.json]
```

### Input graph json spec
The input represents an arrangement graph with samples.  Each graph node represents an arrangement cell, and each graph edge represents an arrangement patch between 2 cells.
```js
{
    "num_cells": ##,
    "patches": [
        {
            "adj_cell_0": ##, // Cell on negative side.
            "adj_cell_1": ##, // Cell on positive side.
            "weight": ##, // Area of the patch.
            "implicit_id": ##, // Index of the implicit function.
            "num_samples": ##, // The number of samples on this patch.
            "adj_patches": [##, ##, ...] // A list of adjacent patch ids.
        },
        ...
    ]
}
```

### Output label
The output is an array of booleans (one per cell) indicating whether that cell is inside.
```js
{"labels":[true,false,false,true,true,false]}
```

