### PR TITLE
Double counting edge weight bug fix.

### DIFF
--- a/cmake/fast_arrangement.cmake
+++ b/cmake/fast_arrangement.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     indirect_predicates
     GIT_REPOSITORY https://github.com/qnzhou/Indirect_Predicates.git
-    GIT_TAG master
+    GIT_TAG c7c9d0b0ce8563b368f032083ecda0854e4feb12
 )
 
 FetchContent_MakeAvailable(indirect_predicates)
@@ -19,7 +19,7 @@ add_library(indirect_predicates::indirect_predicates ALIAS indirectPredicates)
 FetchContent_Declare(
     cinolib
     GIT_REPOSITORY https://github.com/mlivesu/cinolib.git
-    GIT_TAG master
+    GIT_TAG a0cb8ee0345c2515711a48a088c3305283fa49d3
 )
 if(NOT cinolib_POPULATED)
   FetchContent_Populate(cinolib)
@@ -29,7 +29,7 @@ endif()
 FetchContent_Declare(
     fast_arrangement
     GIT_REPOSITORY https://github.com/qnzhou/FastAndRobustMeshArrangements.git
-    GIT_TAG master
+    GIT_TAG 44580b5136adc7acff76e2f6f0ad4556340dd073
 )
 if(NOT fast_arrangement_POPULATED)
   FetchContent_Populate(fast_arrangement)

--- a/cmake/fast_arrangement.cmake
+++ b/cmake/fast_arrangement.cmake
@@ -19,7 +19,7 @@ add_library(indirect_predicates::indirect_predicates ALIAS indirectPredicates)
 FetchContent_Declare(
     cinolib
     GIT_REPOSITORY https://github.com/mlivesu/cinolib.git
-    GIT_TAG v1.0
+    GIT_TAG master
 )
 if(NOT cinolib_POPULATED)
   FetchContent_Populate(cinolib)

--- a/src/BSH.cpp
+++ b/src/BSH.cpp
@@ -505,15 +505,20 @@ void BSH::simple_graph_cut(
             e_reverse = get(boost::edge_reverse,g);
 
     // add edges between blocks
+    std::set<std::array<int, 2>> added_edges;
     for (int p = 0; p < nPatch; ++p) {
         int b1 = P_block[p][0];
         int b2 = P_block[p][1];
-        auto e = add_edge(b1,b2,g).first;
-        e_weights[e] = hPair[Edge(b1,b2)];
-        auto re = add_edge(b2,b1,g).first;
-        e_weights[re] = hPair[Edge(b2,b1)];
-        e_reverse[e] = re;
-        e_reverse[re] = e;
+        if (added_edges.find({b1, b2}) == added_edges.end()) {
+            auto e = add_edge(b1,b2,g).first;
+            e_weights[e] = hPair[Edge(b1,b2)];
+            added_edges.insert({b1, b2});
+            auto re = add_edge(b2,b1,g).first;
+            e_weights[re] = hPair[Edge(b2,b1)];
+            added_edges.insert({b2, b1});
+            e_reverse[e] = re;
+            e_reverse[re] = e;
+        }
     }
 
     // add edges between blocks and terminals (s,t)


### PR DESCRIPTION
Summary:
* In `simple_graph_cut` function, when multiple edges are connecting the same nodes (i.e. an arrangement cell is adjacent to another cell at multiple places), their weights are summed in `hPair` but they are inserted into the graph multiples times with the _summed_ weight.  This leads to incorrect result in corner cases.
* The fix is to combine those edge into one with the summed weight and insert it only once in the graph.
* Update dependencies so it compiles.